### PR TITLE
feat: W3Multicall.call() support sepecify the block_idenfifier

### DIFF
--- a/examples/simple_multicall_with_block_identifier.py
+++ b/examples/simple_multicall_with_block_identifier.py
@@ -1,0 +1,38 @@
+from web3 import Web3
+from w3multicall.multicall import W3Multicall
+
+if __name__ == "__main__":
+
+    rpc = 'https://ethereum.publicnode.com'
+
+    w3 = Web3(Web3.HTTPProvider(rpc))
+
+    w3_multicall = W3Multicall(w3)
+
+    w3_multicall.add(W3Multicall.Call(
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',  # USDC contract address
+        'balanceOf(address)(uint256)',  # method signature to call
+        '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')  # vitalik.eth
+    )
+
+    w3_multicall.add(W3Multicall.Call(
+        '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',  # BAYC NFT contract address
+        'ownerOf(uint256)(address)',  # method signature to call
+        1)
+    )
+
+    w3_multicall.add(W3Multicall.Call(
+        '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',  # WETH contract address
+        'totalSupply()(uint256)'  # method to call
+        )
+    )
+
+    # get the results of the multicall at block number bn - 10
+    # when use the public rpc node, the block number may be outdated
+    # in this example, we use the block number of the current block - 10
+    bn = w3.eth.block_number
+    results = w3_multicall.call(bn - 10)
+
+    print("Vitalik holds {:.2f} USDC".format(results[0]/10**6))
+    print("The owner of the first BAYC NFT is {}".format(results[1]))
+    print("The current supply of WETH is {:.2f}".format(results[2] / 10 ** 18))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ version = "0.3.0"
 readme = "README.md"
 keywords = ["blockchain", "web3", "etherum", "solidity"]
 license = {file = "LICENSE"}
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",

--- a/src/w3multicall/multicall.py
+++ b/src/w3multicall/multicall.py
@@ -2,6 +2,7 @@ from typing import Tuple, List, Union, Optional, Any, Iterable, Callable
 
 import eth_utils
 from eth_typing.abi import Decodable, TypeStr
+from web3.types import BlockIdentifier
 
 # For eth_abi versions < 2.2.0, `decode` and `encode` have not yet been added.
 # As we require web3 ^5.27, we require eth_abi compatibility with eth_abi v2.0.0b6 and greater.
@@ -142,14 +143,14 @@ class W3Multicall:
     def add(self, call: 'W3Multicall.Call'):
         self.calls.append(call)
 
-    def call(self) -> list:
+    def call(self, block_identifier: Optional[BlockIdentifier] = None) -> list:
         args = self._get_args()
         data = _encode_data(W3Multicall.MULTICALL_SELECTOR, W3Multicall.MULTICALL_INPUT_TYPES, args)
         eth_call_params = {
             'to': self.address,
             'data': data
         }
-        rpc_response = self.web3.eth.call(eth_call_params)
+        rpc_response = self.web3.eth.call(eth_call_params, block_identifier=block_identifier)
         aggregated = _decode_output(rpc_response, W3Multicall.MULTICALL_OUTPUT_TYPES)
         unpacked = _unpack_aggregate_outputs(aggregated[1])
         outputs = []


### PR DESCRIPTION
`block_identifier` is an optional parameter. Even if it is not passed in, it will not affect the normal use of `call()`. If this parameter is passed in,
 the data at the specified block height can be queried.